### PR TITLE
[Improve] mkdir_p instead of mkdir for nested base_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Or install it yourself as:
 
 TODO: Write usage instructions here
 
+## See Also
+
+https://github.com/SpringMT/rack-server_status
+
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/worker_scoreboard/fork )
+1. Fork it ( https://github.com/SpringMT/worker_scoreboard/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/worker_scoreboard.rb
+++ b/lib/worker_scoreboard.rb
@@ -1,5 +1,6 @@
 require "worker_scoreboard/version"
 require 'digest/md5'
+require 'fileutils'
 
 class WorkerScoreboard
   def initialize(base_dir)
@@ -15,7 +16,7 @@ class WorkerScoreboard
     ObjectSpace.define_finalizer(self, @clean_proc)
 
     unless Dir.exist? @base_dir
-      Dir.mkdir @base_dir or fail "failed to create directory:#{@base_dir}:#{$!}"
+      FileUtils.mkdir_p @base_dir or fail "failed to create directory:#{@base_dir}:#{$!}"
     end
     begin
       File.unlink build_filename

--- a/spec/worker_scoreboard_spec.rb
+++ b/spec/worker_scoreboard_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 require 'tmpdir'
 
 describe WorkerScoreboard do
-  context do
+  describe '.new' do
+    context 'For nested directory' do
+      let(:base_dir) { File.join(Dir.tmpdir, 'level1', 'level2') }
+      subject { WorkerScoreboard.new(base_dir) }
+      example do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#update' do
     let(:base_dir) { Dir.tmpdir }
     subject { WorkerScoreboard.new(base_dir) }
     it do


### PR DESCRIPTION
Hi,

I want to add this feature to this tool so that it won't fail if someone happens to configure a nested directory as `base_dir`.

Thank you.