### PR TITLE
Fix Encoding::CompatibilityError

### DIFF
--- a/lib/worker_scoreboard.rb
+++ b/lib/worker_scoreboard.rb
@@ -25,6 +25,7 @@ class WorkerScoreboard
   end
 
   def update(status)
+    status.encode!('UTF-8') if [Encoding::UTF_8, Encoding::BINARY].none?(status.encoding)
     if !@fh.nil? && @id_for_fh != worker_id
       @fh.close
       @fh = nil
@@ -41,7 +42,7 @@ class WorkerScoreboard
       @id_for_fh = worker_id
     end
     @fh.seek 0 or raise "seek failed:#{$!}";
-    @fh.write("#{Digest::MD5.digest(status)}#{[status.length].pack("N*")}#{status}")
+    @fh.write("#{Digest::MD5.digest(status)}#{[status.bytesize].pack("N*")}#{status.b}")
     @fh.flush
   end
 
@@ -56,7 +57,7 @@ class WorkerScoreboard
         size = data[16, 4].unpack("N*")
         status = data[20, size[0]]
         next if Digest::MD5.digest(status) != md5
-        ret[id] = status
+        ret[id] = status.force_encoding('UTF-8')
         break
       end
       #warn "failed to read status of id:#{id}, skipping"

--- a/spec/worker_scoreboard_spec.rb
+++ b/spec/worker_scoreboard_spec.rb
@@ -15,9 +15,25 @@ describe WorkerScoreboard do
   describe '#update' do
     let(:base_dir) { Dir.tmpdir }
     subject { WorkerScoreboard.new(base_dir) }
-    it do
+
+    it 'creates a file with the given name and content with only ascii content' do
       subject.update('me manager')
       expect(subject.read_all.values.first).to eq 'me manager'
+    end
+
+    it 'creates a file with the given name and content with utf-8 content' do
+      subject.update('俺マネージャー👨🏿‍💼')
+      expect(subject.read_all.values.first).to eq '俺マネージャー👨🏿‍💼'
+    end
+
+    it 'creates a file with the given name and content with shift-jis content' do
+      subject.update('俺マネージャー'.encode('Shift_JIS'))
+      expect(subject.read_all.values.first).to eq '俺マネージャー'
+    end
+
+    it 'creates a file with the given name and content with euc-jp content' do
+      subject.update('俺マネージャー'.encode('EUC-JP'))
+      expect(subject.read_all.values.first).to eq '俺マネージャー'
     end
   end
 end

--- a/worker_scoreboard.gemspec
+++ b/worker_scoreboard.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This PR resolves an `Encoding::CompatibilityError` by improving how string encodings are managed when worker status updates are written to and read from the scoreboard.

Previously, using `String#length` for size calculation with multi-byte characters could lead to data corruption or errors. This change ensures:

- Consistent UTF-8 Encoding: `status` strings are now explicitly converted to UTF-8 before being written.
- Binary Write Operations: `status.b` ensures strings are treated as byte sequences during writing.
- Forced UTF-8 on Read: Read strings are now `force_encoding('UTF-8')` for correct interpretation.